### PR TITLE
Cleanup of temporary SAM and BAM files

### DIFF
--- a/lib/reads2sams.pl
+++ b/lib/reads2sams.pl
@@ -133,6 +133,13 @@ for (@filestore) {
     $samtools_command = "$samtools_path index \"$final_bam_file\"";
     print "running $samtools_command\n";
     system($samtools_command) == 0 or die "Could not execute $samtools_command";
+
+    # cleanup unneeded files
+    unless ($keep_tmp_files) {
+        unlink "$unsorted_bam_out" || die "Couldn't remove $unsorted_bam_out: $!\n";
+        unlink "$new_out_file" || die "Couldn't remove $new_out_file: $!\n";
+        unlink "$out_sam_file" || die "Couldn't remove $out_sam_file: $!\n";
+    }
 }
 
 unless ($keep_tmp_files) {


### PR DESCRIPTION
Cleans up the temporary SAM and BAM files in the `mapping/` and `sam/` directory (for issue #9).  Removes the majority of the unneded files being stored.  For example

original `du -s *`

```
288114  output_original/mapping
84666   output_original/sam
63106   output_original/bam
44354   output_original/mpileup
```

new `du -s *`

```
63106   output_new/bam
44354   output_new/mpileup
...
474     output_new/mapping
...
2       output_new/sam
```

Any other files we should be cleaning up (I still like keeping around one copy of the BAM files)?
